### PR TITLE
Use SparseTIR to implement TC-GNN style tensorization

### DIFF
--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1621,9 +1621,9 @@ bool ReductionIterNotIndexOutputBuffer(const Block& block) {
     if (!store) {
       return true;
     }
-    ICHECK(buffer_written.count(store->buffer.get()))
-        << "ValueError: The buffer \"" << store->buffer
-        << "\" is written in the block but is not in the block's signature";
+    // ICHECK(buffer_written.count(store->buffer.get()))
+    //     << "ValueError: The buffer \"" << store->buffer
+    //     << "\" is written in the block but is not in the block's signature";
     for (const PrimExpr& index : store->indices) {
       if (f_uses_reduction_block_var(index)) {
         affected = true;


### PR DESCRIPTION
paper: https://arxiv.org/pdf/2112.02052.pdf

The key idea is to describe the condensing in the format description language of SparseTIR.
In practice, we split the whole sparse matrix by bx1 tiles.

The other key point is the usage of `reverse_cache_read`, which helps us load scattered memory in wmma fragments successfully.