### PR TITLE
[Bugfix] Fix the behavior of MatchToAlloc and Reverse Cache Read/Write

### DIFF
--- a/src/tir/schedule/primitive/block_annotate.cc
+++ b/src/tir/schedule/primitive/block_annotate.cc
@@ -474,17 +474,9 @@ void MatchToAlloc(ScheduleState self, const StmtSRef& block_sref, int buffer_ind
       << "The buffer to transform must be a top-level matched buffer.";
 
   // Create new allocated buffer.
-  Buffer alloc_buffer;
-  if (buffer->IsInstance<SparseBufferNode>()) {
-    ObjectPtr<SparseBufferNode> alloc_buffer_node =
-        make_object<SparseBufferNode>(*buffer.as<SparseBufferNode>());
-    alloc_buffer_node->name = buffer->name + "_tmp";
-    alloc_buffer = SparseBuffer(alloc_buffer_node);
-  } else {
-    ObjectPtr<BufferNode> alloc_buffer_node = make_object<BufferNode>(*buffer.get());
-    alloc_buffer_node->name = buffer->name + "_tmp";
-    alloc_buffer = Buffer(alloc_buffer_node);
-  }
+  ObjectPtr<BufferNode> alloc_buffer_node = make_object<BufferNode>(*buffer.get());
+  alloc_buffer_node->name = buffer->name + "_tmp";
+  Buffer alloc_buffer = Buffer(alloc_buffer_node);
 
   const StmtSRefNode* root_block_sref_node = nullptr;
   const BlockNode* root_block_node = nullptr;

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -1198,8 +1198,11 @@ StmtSRef ReverseCacheRead(ScheduleState self, const StmtSRef& block_sref, int re
     collector(touched_info.iter_values.back());
   }
 
-  for (const StmtSRef loop_sref : GetLoops(block_sref)) {
-    const ForNode* loop = TVM_SREF_TO_FOR(loop, loop_sref);
+  for (StmtSRefNode* p = block_sref->parent; p && p->stmt->IsInstance<ForNode>(); p = p->parent) {
+    const StmtSRef& sref = GetRef<StmtSRef>(p);
+    // NOTE(Zihao): do not generate duplicate loops
+    if (sref.same_as(info.loc_sref)) break;
+    const ForNode* loop = TVM_SREF_TO_FOR(loop, sref);
     if (collector.touched.count(loop->loop_var.get())) {
       touched_info.loop_vars.push_back(loop->loop_var);
       touched_info.loop_ranges.push_back(Range::FromMinExtent(loop->min, loop->extent));
@@ -1314,8 +1317,11 @@ StmtSRef ReverseCacheWrite(ScheduleState self, const StmtSRef& block_sref, int w
     collector(touched_info.iter_values.back());
   }
 
-  for (const StmtSRef loop_sref : GetLoops(block_sref)) {
-    const ForNode* loop = TVM_SREF_TO_FOR(loop, loop_sref);
+  for (StmtSRefNode* p = block_sref->parent; p && p->stmt->IsInstance<ForNode>(); p = p->parent) {
+    const StmtSRef& sref = GetRef<StmtSRef>(p);
+    // NOTE(Zihao): do not generate duplicate loops
+    if (sref.same_as(info.loc_sref)) break;
+    const ForNode* loop = TVM_SREF_TO_FOR(loop, sref);
     if (collector.touched.count(loop->loop_var.get())) {
       touched_info.loop_vars.push_back(loop->loop_var);
       touched_info.loop_ranges.push_back(Range::FromMinExtent(loop->min, loop->extent));


### PR DESCRIPTION
This PR fix the two issues:
1. MatchToAlloc generates an `AllocSparseBuffer` instead of `AllocBuffer` for sparse tensors, actually to make `CompactBufferRegion` work, we need to allocate original multi-dimensional buffers.
2. Reverse Cache Read/Write might generate redundant loops when generated block was placed under existing loops.