### PR TITLE
[Feature] Add `block_filter` attribute in ScheduleState to enable scheduling a subset of blocks.

### DIFF
--- a/include/tvm/tir/schedule/state.h
+++ b/include/tvm/tir/schedule/state.h
@@ -102,6 +102,10 @@ class ScheduleStateNode : public Object {
    * \sa ScheduleDebugMask
    */
   int debug_mask;
+  /*!
+   * \brief The filter to apply on blocks.
+   */
+  Optional<String> block_filter = NullOpt;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("mod", &mod);
@@ -150,6 +154,14 @@ class ScheduleStateNode : public Object {
    * have block vars, since the affine flag depends on the outer scope of stmt.
    */
   TVM_DLL void UpdateScopeBlockInfo(const Stmt& stmt);
+  /*!
+   * \brief Set block filter.
+   */
+  TVM_DLL void SetBlockFilter(String name);
+  /*!
+   * \brief Unset block filter.
+   */
+  TVM_DLL void UnsetBlockFilter();
   /*!
    * \brief Get the BlockScope correpsonding to the sref of scope root block
    * \param scope_root The block sref to be retrieved

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -198,6 +198,12 @@ class Schedule(Object):
         """Returns the internally maintained trace of scheduling program execution"""
         return _ffi_api.ScheduleGetTrace(self)  # type: ignore # pylint: disable=no-member
 
+    def set_block_filter(self, name: str) -> None:
+        _ffi_api.ScheduleSetBlockFilter(self.state, name)  # type: ignore # pylint: disable=no-member
+
+    def unset_block_filter(self) -> None:
+        _ffi_api.ScheduleUnsetBlockFilter(self.state)  # type: ignore # pylint: disable=no-member
+
     def copy(self) -> "Schedule":
         """Returns a copy of the schedule, including both the state and the symbol table,
         * guaranteeing that

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -416,7 +416,7 @@ class StateCreator : private StmtVisitor {
         BlockInfoCollector::Collect(self, func->body);
       }
     }
-    for (const BufferDomain& buf_dom: creator.buf_doms) {
+    for (const BufferDomain& buf_dom : creator.buf_doms) {
       const Buffer& buf = buf_dom->buffer;
       const Range& dom = buf_dom->dom;
       n->buf_dom_map.Set(buf, dom);
@@ -462,7 +462,7 @@ class StateCreator : private StmtVisitor {
   void VisitStmt_(const BlockRealizeNode* realize) final {
     const BlockNode* block = realize->block.get();
     PushSRef(block);
-    for (const BufferDomain& buf_dom: block->buf_doms) {
+    for (const BufferDomain& buf_dom : block->buf_doms) {
       buf_doms.push_back(buf_dom);
     }
     VisitStmt(block->body);  // `block->init` is not visited
@@ -1107,6 +1107,10 @@ TVM_DLL Array<Bool> GetCachedFlags(const ScheduleState& self, const StmtSRef& bl
           Bool(info.scope->stage_pipeline)};
 }
 
+/**************** Block filter related API ****************/
+TVM_DLL void ScheduleStateNode::SetBlockFilter(String name) { block_filter = name; }
+TVM_DLL void ScheduleStateNode::UnsetBlockFilter() { block_filter = NullOpt; }
+
 /**************** FFI ****************/
 
 TVM_REGISTER_NODE_TYPE(ScheduleStateNode);
@@ -1116,6 +1120,10 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleState")
     });
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleStateGetBlockScope")
     .set_body_method<ScheduleState>(&ScheduleStateNode::GetBlockScope);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleSetBlockFilter")
+    .set_body_method<ScheduleState>(&ScheduleStateNode::SetBlockFilter);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleUnsetBlockFilter")
+    .set_body_method<ScheduleState>(&ScheduleStateNode::UnsetBlockFilter);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleStateReplace")
     .set_body_method<ScheduleState>(&ScheduleStateNode::Replace);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleStateGetSRef")


### PR DESCRIPTION
Composable format would create many blocks that might read the same buffer, and currently the `cache_read`/`cache_write` schedule primitives will rewrite buffers in all blocks. 

However, the schedules applied to blocks generated by different formats should be treated independently, to enable this behavior, we create a `block_filter` attribute in `ScheduleState` class.

Whenever we only want to schedule a subset of blocks, we can annotate them with keywords, and set block filters in schedule:
```python
sch.annotate(block, "group_1", 1)
sch.set_block_filter("group_1")
# START OF SUBSET SCHEDULES
# ...
# END OF SUBSET SCHEDULES
sch.unset_block_filter()
```