### PR TITLE
[Bugfix] Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 SparseTIR: Sparse Tensor Compiler for Deep Learning
 ==============================================
-[Documentation](https://sampl.cs.washington.edu/sparsetir/) |
+[Documentation](https://sampl.cs.washington.edu/SparseTIR/) |
 [Paper](https://arxiv.org/abs/2207.04606)
 
 [![Build Status](https://github.com/uwsampl/sparsetir/actions/workflows/build.yml/badge.svg)](https://github.com/uwsampl/sparsetir/actions/workflows/build.yml)
@@ -29,7 +29,7 @@ The key innovation of SparseTIR is *composability*:
 - **Format Composability**: Decompose the computation on a single format to computation on hybrid formats.
 - **Transformation Composability**: SparseTIR adopts multi-stage IR design on top of TVM's TensorIR, user can compose program transformations at different stages to bring together sparsity-aware optimizations such as format searching and low-level optimizations such as vectorization and tensorization.
 
-Check out the [Documentation](https://sampl.cs.washington.edu/sparsetir/) site for installation instructions, tutorials, examples, and more. The [Blitz Introduction to SparseTIR](https://sampl.cs.washington.edu/sparsetir/tutorials/blitz.html) is a great place to get you familiar with SparseTIR's format annotations and compilation flow. You can check the tutorials on optimizing [SpMM](https://sampl.cs.washington.edu/sparsetir/tutorials/spmm.html) and [RGMS](https://sampl.cs.washington.edu/sparsetir/tutorials/rgcn.html) to understand how to use composable formats and composable transformations to optimize sparse operators.
+Check out the [Documentation](https://sampl.cs.washington.edu/SparseTIR/) site for installation instructions, tutorials, examples, and more. The [Blitz Introduction to SparseTIR](https://sampl.cs.washington.edu/SparseTIR/tutorials/blitz.html) is a great place to get you familiar with SparseTIR's format annotations and compilation flow. You can check the tutorials on optimizing [SpMM](https://sampl.cs.washington.edu/SparseTIR/tutorials/spmm.html) and [RGMS](https://sampl.cs.washington.edu/SparseTIR/tutorials/rgcn.html) to understand how to use composable formats and composable transformations to optimize sparse operators.
 
 This repo is still experimental and documentations are under construction, the API will not be stable and we will frequently refactor the codebase. However, we believe making it public will benefit researchers and engineers in this field. Feel free to create an issue if you run into any problems or have any suggestions on SparseTIR. We plan to contribute SparseTIR to Apache TVM project as an optional module, and we will keep maintaining this repo until the core functionalities have been upstreamed. The codebase is mainly developed and maintained by [Ruihang Lai](https://github.com/MasterJH5574) and [Zihao Ye](https://github.com/yzh119/), some early commits are rebased and squashed when syncing with Apache TVM upstream.
 


### PR DESCRIPTION
The repo's name has changed to `SparseTIR` and the documentation link needs to be revised correspondingly.