### PR TITLE
Revert "[hotfix] Use `repeat` instead of `number`"

### DIFF
--- a/examples/blocksparse/bsr_spmm.py
+++ b/examples/blocksparse/bsr_spmm.py
@@ -432,7 +432,7 @@ def bench_bsrmm(bsr_mat: Any, x: th.Tensor):
     args = [A_data, X_nd, Y_nd, A_indptr, A_indices]
     f(*args)
 
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=100)
     avg_time = evaluator(*args).mean
     print("bsrmm time: \t{:.5f}ms".format(avg_time * 1000))
     return avg_time * 1000

--- a/examples/rgms/rgcn/bench_rgcn_composable.py
+++ b/examples/rgms/rgcn/bench_rgcn_composable.py
@@ -224,7 +224,7 @@ def test_rgcn_composable_format(
     tvm.testing.assert_allclose(Y_nd.numpy(), ground_truth_y.cpu().numpy().flatten(), rtol=1e-3)
 
     # evaluate time
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=10)
     print("sparse-tir:\t\t {:.3f} ms".format(evaluator(*args).mean * 1000))
 
 

--- a/examples/rgms/rgcn/bench_rgcn_non_composable.py
+++ b/examples/rgms/rgcn/bench_rgcn_non_composable.py
@@ -109,7 +109,7 @@ def test_lower_rgcn_hetero(
     f(*args)
 
     # evaluate time
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=10)
     print("sparse-tir: {:.3f}".format(evaluator(*args).mean * 1000))
 
 

--- a/examples/rgms/rgcn/bench_rgcn_tensorcore.py
+++ b/examples/rgms/rgcn/bench_rgcn_tensorcore.py
@@ -853,7 +853,7 @@ def rgcn_tensorcore(
     answer = Y_nd.numpy()
 
     # evaluate time
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=10)
     print("sparse-tir:\t\t{:.3f} ms".format(evaluator(*args).mean * 1000))
     return answer
 

--- a/examples/rgms/sparse_conv/rgms.py
+++ b/examples/rgms/sparse_conv/rgms.py
@@ -858,7 +858,7 @@ def rgms_tensorcore(
     answer = Y_nd.numpy()
 
     # evaluate time
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=10)
     measure = evaluator(*args).mean * 1000
     print("sparse-tir:\t\t{:.3f} ms".format(measure))
     return answer, measure

--- a/examples/sddmm/bench_sddmm.py
+++ b/examples/sddmm/bench_sddmm.py
@@ -172,7 +172,7 @@ def bench_sddmm(g: dgl.DGLGraph, feat_size: int):
                     tvm.testing.assert_allclose(c_nd.numpy(), c_golden.view(-1).cpu(), rtol=1e-5)
 
                     # evaluate time
-                    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+                    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=10)
                     mean_time = evaluator(*args).mean * 1000
 
                     if mean_time < best:

--- a/examples/spmm/bench_spmm.py
+++ b/examples/spmm/bench_spmm.py
@@ -226,7 +226,7 @@ def bench_hyb(
     tvm.testing.assert_allclose(c_nd.numpy().reshape(-1, feat_size), y_golden.numpy(), rtol=1e-4)
 
     # evaluate time
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=100)
     print("tir hyb time: {:.5f}ms".format(evaluator(*args).mean * 1000))
 
 

--- a/examples/spmm/bench_spmm_naive.py
+++ b/examples/spmm/bench_spmm_naive.py
@@ -129,7 +129,7 @@ def bench_hyb(
     args = [a_nd, b_nd, c_nd, indptr_nd, indices_nd]
     f(*args)
     tvm.testing.assert_allclose(c_nd.numpy().reshape(-1, feat_size), y_golden.numpy(), rtol=1e-4)
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=100)
     print("tir naive time: {:.5f} ms".format(evaluator(*args).mean * 1000))
 
 

--- a/examples/spmm/bench_tc_spmm.py
+++ b/examples/spmm/bench_tc_spmm.py
@@ -660,7 +660,7 @@ def bench_tc_spmm(g: dgl.DGLHeteroGraph, x: th.Tensor, y_golden: th.Tensor, mma_
         c_nd.numpy().reshape(-1, feat_size)[:m], y_golden.cpu().numpy(), rtol=1e-1
     )
 
-    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=1, repeat=100)
+    evaluator = f.time_evaluator(f.entry_name, tvm.cuda(0), number=100)
     print("tc-spmm time: {:.5f}ms".format(evaluator(*args).mean * 1000))
 
 


### PR DESCRIPTION
Per experiments, using `number` instead of `repeat` aligns with the torch profiler's behavior. So we revert PR #85 for now.
