### PR TITLE
[Hotfix] Fix the linking issue that `libPolly.a` is missing

### DIFF
--- a/docker/install/install_sparsetir_gpu.sh
+++ b/docker/install/install_sparsetir_gpu.sh
@@ -24,7 +24,7 @@ then
 fi
 
 # Compile C++ source code.
-echo set\(USE_LLVM \"llvm-config-15 --ignore-libllvm --link-static\"\) >> config.cmake
+echo set\(USE_LLVM \"llvm-config-13 --ignore-libllvm --link-static\"\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_CUDA ON\) >> config.cmake
 echo set\(USE_CUBLAS ON\) >> config.cmake

--- a/docker/install/install_sparsetir_gpu.sh
+++ b/docker/install/install_sparsetir_gpu.sh
@@ -24,7 +24,7 @@ then
 fi
 
 # Compile C++ source code.
-echo set\(USE_LLVM \"llvm-config-14 --ignore-libllvm --link-static\"\) >> config.cmake
+echo set\(USE_LLVM \"llvm-config-15 --ignore-libllvm --link-static\"\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_CUDA ON\) >> config.cmake
 echo set\(USE_CUBLAS ON\) >> config.cmake

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -29,7 +29,7 @@ echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main\
 
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 
-apt-get update && install -y \
+apt-get update && apt-get install -y \
      llvm-9 llvm-10 llvm-11 llvm-12 llvm-13 \
      clang-9 libclang-9-dev \
      clang-10 libclang-10-dev \

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -20,20 +20,19 @@ set -e
 set -u
 set -o pipefail
 
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-# or
-wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
 
-echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
-echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
+echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main\
+    >> /etc/apt/sources.list.d/llvm.list
 
-# 15
-echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main >> /etc/apt/sources.list.d/llvm.list
-echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main >> /etc/apt/sources.list.d/llvm.list
+echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main\
+    >> /etc/apt/sources.list.d/llvm.list
 
-wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 
-apt-get update && apt-get install -y \
-     llvm-15 clang-format-15 \
-     clang-15 libclang-15-dev libpolly-15-dev
+apt-get update && apt-install-and-clear -y \
+     llvm-9 llvm-10 llvm-11 llvm-12 llvm-13 \
+     clang-9 libclang-9-dev \
+     clang-10 libclang-10-dev \
+     clang-11 libclang-11-dev \
+     clang-12 libclang-12-dev \
+     clang-13 libclang-13-dev

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -29,7 +29,7 @@ echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main\
 
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 
-apt-get update && apt-install-and-clear -y \
+apt-get update && install -y \
      llvm-9 llvm-10 llvm-11 llvm-12 llvm-13 \
      clang-9 libclang-9-dev \
      clang-10 libclang-10-dev \

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -31,4 +31,4 @@ wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 
 apt-get update && apt-get install -y \
      llvm-14 clang-format-14 \
-     clang-14 libclang-14-dev libpolly-14-dev libclang-common-14-dev
+     clang-14 libclang-14-dev libclang-common-14-dev

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -30,9 +30,5 @@ echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main\
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 
 apt-get update && apt-get install -y \
-     llvm-9 llvm-10 llvm-11 llvm-12 llvm-13 \
-     clang-9 libclang-9-dev \
-     clang-10 libclang-10-dev \
-     clang-11 libclang-11-dev \
-     clang-12 libclang-12-dev \
-     clang-13 libclang-13-dev
+     llvm-13 \
+     clang-13 libclang-13-dev clang-format-13

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -20,15 +20,20 @@ set -e
 set -u
 set -o pipefail
 
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+# or
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
+
 echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
 echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
 
-# 14
-echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
-echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
+# 15
+echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main >> /etc/apt/sources.list.d/llvm.list
 
 wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 
 apt-get update && apt-get install -y \
-     llvm-14 clang-format-14 \
-     clang-14 libclang-14-dev libclang-common-14-dev
+     llvm-15 clang-format-15 \
+     clang-15 libclang-15-dev libpolly-15-dev

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -31,4 +31,4 @@ wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 
 apt-get update && apt-get install -y \
      llvm-14 clang-format-14 \
-     clang-14 libclang-14-dev
+     clang-14 libclang-14-dev libpolly-14-dev

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -20,15 +20,8 @@ set -e
 set -u
 set -o pipefail
 
-echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
-echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
+bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
-# 14
-echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
-echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
-
-wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-
-apt-get update && apt-get install -y \
-     llvm-14 clang-format-14 \
-     clang-14 libclang-14-dev libpolly-14-dev
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 14 all

--- a/docker/install/ubuntu2004_install_llvm.sh
+++ b/docker/install/ubuntu2004_install_llvm.sh
@@ -20,8 +20,15 @@ set -e
 set -u
 set -o pipefail
 
-bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main >> /etc/apt/sources.list.d/llvm.list
 
-wget https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-sudo ./llvm.sh 14 all
+# 14
+echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main >> /etc/apt/sources.list.d/llvm.list
+
+wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+
+apt-get update && apt-get install -y \
+     llvm-14 clang-format-14 \
+     clang-14 libclang-14-dev libpolly-14-dev libclang-common-14-dev

--- a/tests/lint/git-clang-format.sh
+++ b/tests/lint/git-clang-format.sh
@@ -55,10 +55,10 @@ cleanup()
 }
 trap cleanup 0
 
-if [ -x "$(command -v clang-format-14)" ]; then
-    CLANG_FORMAT=clang-format-14
+if [ -x "$(command -v clang-format-15)" ]; then
+    CLANG_FORMAT=clang-format-15
 else
-    echo "Cannot find clang-format-14"
+    echo "Cannot find clang-format-15"
     exit 1
 fi
 

--- a/tests/lint/git-clang-format.sh
+++ b/tests/lint/git-clang-format.sh
@@ -55,10 +55,10 @@ cleanup()
 }
 trap cleanup 0
 
-if [ -x "$(command -v clang-format-15)" ]; then
-    CLANG_FORMAT=clang-format-15
+if [ -x "$(command -v clang-format-13)" ]; then
+    CLANG_FORMAT=clang-format-13
 else
-    echo "Cannot find clang-format-15"
+    echo "Cannot find clang-format-13"
     exit 1
 fi
 


### PR DESCRIPTION
We encounter the error in CI in the linking stage of TVM build:
```
make[2]: *** No rule to make target ‘/usr/lib/llvm-14/lib/libPolly.a’, needed by ‘libtvm.so’. Stop.
make[1]: *** [CMakeFiles/Makefile2:934: CMakeFiles/tvm.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target ‘/usr/lib/llvm-14/lib/libPolly.a’, needed by ‘libtvm_allvisible.so’. Stop.
make[1]: *** [CMakeFiles/Makefile2:1017: CMakeFiles/tvm_allvisible.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
and this issue was caused by refactoring of LLVM apt source:
- https://discourse.llvm.org/t/llvm-15-0-7-missing-libpolly-a/67942
- https://discourse.llvm.org/t/ubuntu-packages-with-llvm-14-then-15-suddenly-looking-for-libpolly-a/67655

This PR fix the issue by downgrad LLVM 14 to LLVM 13.