### PR TITLE
[Primitive] New schedule primitive: `reorder_block_itervar`

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -338,6 +338,12 @@ class ScheduleNode : public runtime::Object {
    */
   virtual void Reorder(const Array<LoopRV>& ordered_loop_rvs) = 0;
   /*!
+   * \brief Reorder the itervars inside a block.
+   * \param block_rv The block to be transformed.
+   * \param new_order The new itervar order.
+   */
+  virtual void ReorderBlockIterVar(const BlockRV& block_rv, const Array<Integer> new_order) = 0;
+  /*!
    * \brief Lift a loop to its outer block.
    * \note TODO(zihao): write something about requirements.
    */

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -705,6 +705,18 @@ class Schedule(Object):
         _ffi_api.ScheduleReorder(self, ordered_loops)  # type: ignore # pylint: disable=no-member
 
     @type_checked
+    def reorder_block_iter_var(self, block: BlockRV, new_order: List[int]) -> None:
+        """Reorder the itervars inside a given block.
+        Parameters
+        ----------
+        block : BlockRV
+            The block to be transformed. 
+        new_order : List[int]
+            The new block itervar order.
+        """
+        _ffi_api.ScheduleReorderBlockIterVar(self, block, new_order)  # type: ignore # pylint: disable=no-member
+
+    @type_checked
     def lift_loop(self, loop: LoopRV) -> None:
         """Lift a loop to its outer block.
 

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -710,7 +710,7 @@ class Schedule(Object):
         Parameters
         ----------
         block : BlockRV
-            The block to be transformed. 
+            The block to be transformed.
         new_order : List[int]
             The new block itervar order.
         """

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -453,6 +453,14 @@ void ConcreteScheduleNode::Reorder(const Array<LoopRV>& ordered_loop_rvs) {
   this->state_->DebugVerify();
 }
 
+void ConcreteScheduleNode::ReorderBlockIterVar(const BlockRV& block_rv,
+                                               const Array<Integer> new_order) {
+  TVM_TIR_SCHEDULE_BEGIN();
+  tir::ReorderBlockIterVar(state_, GetSRef(block_rv), new_order);
+  TVM_TIR_SCHEDULE_END("reorder_block_iter_var", this->error_render_level_);
+  this->state_->DebugVerify();
+}
+
 void ConcreteScheduleNode::LiftLoop(const LoopRV& loop_rv) {
   TVM_TIR_SCHEDULE_BEGIN();
   StmtSRef loop_sref = this->GetSRef(loop_rv);

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -103,6 +103,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   LoopRV Fuse(const Array<LoopRV>& loop_rvs) override;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors) override;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) override;
+  void ReorderBlockIterVar(const BlockRV& block_rv, const Array<Integer> new_order) override;
   void LiftLoop(const LoopRV& loop_rv) override;
   /******** Schedule: Manipulate ForKind ********/
   void Parallel(const LoopRV& loop_rv) override;

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -185,7 +185,14 @@ TVM_DLL StmtSRef Fuse(ScheduleState self, const Array<StmtSRef>& loop_srefs);
  * \param ordered_loop_srefs An array of srefs which indicates the new order of loops
  */
 TVM_DLL void Reorder(ScheduleState self, const Array<StmtSRef>& ordered_loop_srefs);
-
+/*!
+ * \brief Reorder itervars inside a block.
+ * \param self The state of the schedule.
+ * \param block_sref The sref of block to be transformed.
+ * \param new_order The new itervar order.
+ */
+TVM_DLL void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
+                                 const Array<Integer>& new_order);
 /*!
  * \brief Lift a loop to its outer scope.
  * TODO(zihao): docstring

--- a/src/tir/schedule/primitive/reorder_block_iter_var.cc
+++ b/src/tir/schedule/primitive/reorder_block_iter_var.cc
@@ -78,7 +78,7 @@ void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
   // check whether new_order is valid or not;
   int num_block_itervars = block_n->iter_vars.size();
   std::set<int> ind_set(new_order_vec.begin(), new_order_vec.end());
-  bool is_full = int(new_order_vec.size()) == num_block_itervars;
+  bool is_full = static_cast<int>(new_order_vec.size()) == num_block_itervars;
   bool is_unique = (ind_set.size() == new_order_vec.size());
   bool in_boundary = std::all_of(new_order_vec.begin(), new_order_vec.end(),
                                  [&](int x) { return x >= 0 && x < num_block_itervars; });

--- a/src/tir/schedule/primitive/reorder_block_iter_var.cc
+++ b/src/tir/schedule/primitive/reorder_block_iter_var.cc
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "../utils.h"
+
+namespace tvm {
+namespace tir {
+
+class WrongReorderIndex : public ScheduleError {
+ public:
+  explicit WrongReorderIndex(IRModule mod) : mod_(mod) {}
+  IRModule mod() const final { return mod_; }
+  String FastErrorString() const final {
+    return "ScheduleError: The specified reorder indices are invalid.";
+  }
+  String DetailRenderTemplate() const final {
+    return "reorder_block_iter_var requires the specified reorder indices to be a permutation of "
+           "{0, 1, ..., num_block_iter_vars - 1}.";
+  }
+  Array<ObjectRef> LocationsOfInterest() const final { return {}; }
+  IRModule mod_;
+};
+
+class BlockIterVarRewriter : public StmtMutator {
+ public:
+  Map<Block, Block> block_map;
+  explicit BlockIterVarRewriter(const BlockNode* block_n, std::vector<int> order)
+      : order_(std::move(order)), block_to_rewrite(block_n) {}
+
+ private:
+  std::vector<int> order_;
+  const BlockNode* block_to_rewrite;
+  Stmt VisitStmt_(const BlockRealizeNode* op) final {
+    if (op->block.get() == block_to_rewrite) {
+      auto block_n = CopyOnWrite(op->block.get());
+      Block block = op->block;
+      Array<IterVar> new_iter_vars;
+      Array<PrimExpr> new_iter_values;
+      for (int idx : order_) {
+        new_iter_vars.push_back(block->iter_vars[idx]);
+        new_iter_values.push_back(op->iter_values[idx]);
+      }
+      block_n->iter_vars = new_iter_vars;
+      Block new_block(block_n);
+      block_map.Set(block, new_block);
+      auto block_realize_n = CopyOnWrite(op);
+      block_realize_n->block = new_block;
+      block_realize_n->iter_values = new_iter_values;
+      return BlockRealize(block_realize_n);
+    } else {
+      return StmtMutator::VisitStmt_(op);
+    }
+  }
+};
+
+void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
+                         const Array<Integer>& new_order) {
+  const BlockNode* block_n = TVM_SREF_TO_BLOCK(block_n, block_sref);
+  std::vector<int> new_order_vec;
+  for (const Integer& x : new_order) {
+    new_order_vec.push_back(x->value);
+  }
+  // check whether new_order is valid or not;
+  int num_block_itervars = block_n->iter_vars.size();
+  std::set<int> ind_set(new_order_vec.begin(), new_order_vec.end());
+  bool is_full = int(new_order_vec.size()) == num_block_itervars;
+  bool is_unique = (ind_set.size() == new_order_vec.size());
+  bool in_boundary = std::all_of(new_order_vec.begin(), new_order_vec.end(),
+                                 [&](int x) { return x >= 0 && x < num_block_itervars; });
+  if (!is_full || !is_unique || !in_boundary) {
+    throw WrongReorderIndex(self->mod);
+  }
+
+  // find parent block
+  const BlockNode* parent_block_n = nullptr;
+  const StmtSRefNode* p = block_sref.get()->parent;
+  while (p != nullptr) {
+    if (p->stmt->IsInstance<BlockNode>()) {
+      parent_block_n = TVM_SREF_TO_BLOCK(parent_block_n, GetRef<StmtSRef>(p));
+      break;
+    }
+    p = p->parent;
+  }
+  const StmtSRef parent_block_sref = GetRef<StmtSRef>(p);
+  const Block& parent_block = GetRef<Block>(parent_block_n);
+
+  // rewrite block and blockrealize
+  BlockIterVarRewriter rewriter(block_n, std::move(new_order_vec));
+  Block new_parent_block = Downcast<Block>(rewriter(parent_block));
+  rewriter.block_map.Set(parent_block, new_parent_block);
+  self->Replace(parent_block_sref, new_parent_block, rewriter.block_map);
+}
+
+struct ReorderBlockIterVarTraits : public UnpackedInstTraits<ReorderBlockIterVarTraits> {
+  static constexpr const char* kName = "ReorderBlockIterVar";
+  static constexpr bool kIsPure = false;
+
+ private:
+  static constexpr size_t kNumInputs = 2;
+  static constexpr size_t kNumAttrs = 0;
+  static constexpr size_t kNumDecisions = 0;
+
+  static void UnpackedApplyToSchedule(Schedule sch, BlockRV block, Array<Integer> new_order) {
+    sch->ReorderBlockIterVar(block, new_order);
+  }
+
+  static String UnpackedAsPython(Array<String> outputs, String block, Array<Integer> new_order) {
+    PythonAPICall py("reorder_block_iter_var");
+    py.Input("block", block);
+    py.Input("new_order", new_order);
+    return py.Str();
+  }
+
+  template <typename>
+  friend struct ::tvm::tir::UnpackedInstTraits;
+};
+
+TVM_REGISTER_INST_KIND_TRAITS(ReorderBlockIterVarTraits);
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -165,6 +165,8 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleFuse").set_body_method<Schedule>(&Sche
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleSplit").set_body_method<Schedule>(&ScheduleNode::Split);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorder")
     .set_body_method<Schedule>(&ScheduleNode::Reorder);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorderBlockIterVar")
+    .set_body_method<Schedule>(&ScheduleNode::ReorderBlockIterVar);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleLiftLoop")
     .set_body_method<Schedule>(&ScheduleNode::LiftLoop);
 /******** (FFI) Manipulate ForKind ********/

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -198,6 +198,15 @@ void TracedScheduleNode::Reorder(const Array<LoopRV>& ordered_loop_rvs) {
                                       /*outputs=*/{}));
 }
 
+void TracedScheduleNode::ReorderBlockIterVar(const BlockRV& block_rv,
+                                             const Array<Integer> new_order) {
+  ConcreteScheduleNode::ReorderBlockIterVar(block_rv, new_order);
+  static const InstructionKind& kind = InstructionKind::Get("ReorderBlockIterVar");
+  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
+                                      /*inputs=*/{block_rv, new_order}, /*attrs=*/{},
+                                      /*outputs=*/{}));
+}
+
 void TracedScheduleNode::LiftLoop(const LoopRV& loop_rv) {
   ConcreteScheduleNode::LiftLoop(loop_rv);
 

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -63,6 +63,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   LoopRV Fuse(const Array<LoopRV>& loop_rvs) final;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factor_rvs) final;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) final;
+  void ReorderBlockIterVar(const BlockRV& block_rv, const Array<Integer> new_order) final;
   void LiftLoop(const LoopRV& loop_rv) final;
   /******** Schedule: Manipulate ForKind ********/
   void Parallel(const LoopRV& loop_rv) final;

--- a/tests/python/unittest/test_tir_reorder_block_iter_var.py
+++ b/tests/python/unittest/test_tir_reorder_block_iter_var.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm import tir
+from tvm.script import tir as T
+from tvm.tir.schedule.testing import verify_trace_roundtrip
+
+
+@T.prim_func
+def matmul(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"], C: T.Buffer[(128, 128), "float32"]) -> None:
+    for i, j, k in T.grid(128, 128, 128):
+        with T.block("C"):
+            vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+            with T.init():
+                C[vi, vj] = 0.0
+            C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+
+@T.prim_func
+def matmul_after_reorder_block_iter_var(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"], C: T.Buffer[(128, 128), "float32"]):
+    for i, j, k in T.grid(128, 128, 128):
+        with T.block("C"):
+            vk, vj, vi = T.axis.remap("RSS", [k, j, i])
+            T.reads(A[vi, vk], B[vj, vk])
+            T.writes(C[vi, vj])
+            with T.init():
+                C[vi, vj] = T.float32(0)
+            C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+
+
+def test_reorder_block_iter_var():
+    sch = tir.Schedule(matmul, debug_mask="all")
+    C = sch.get_block("C")
+    sch.reorder_block_iter_var(C, [2, 1, 0])
+    tvm.ir.assert_structural_equal(matmul_after_reorder_block_iter_var, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=matmul)
+
+
+if __name__ == "__main__":
+    test_reorder_block_iter_var()

--- a/tests/python/unittest/test_tir_reorder_block_iter_var.py
+++ b/tests/python/unittest/test_tir_reorder_block_iter_var.py
@@ -23,7 +23,11 @@ from tvm.tir.schedule.testing import verify_trace_roundtrip
 
 
 @T.prim_func
-def matmul(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"], C: T.Buffer[(128, 128), "float32"]) -> None:
+def matmul(
+    A: T.Buffer[(128, 128), "float32"],
+    B: T.Buffer[(128, 128), "float32"],
+    C: T.Buffer[(128, 128), "float32"],
+) -> None:
     for i, j, k in T.grid(128, 128, 128):
         with T.block("C"):
             vi, vj, vk = T.axis.remap("SSR", [i, j, k])
@@ -31,8 +35,13 @@ def matmul(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"
                 C[vi, vj] = 0.0
             C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
 
+
 @T.prim_func
-def matmul_after_reorder_block_iter_var(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"], C: T.Buffer[(128, 128), "float32"]):
+def matmul_after_reorder_block_iter_var(
+    A: T.Buffer[(128, 128), "float32"],
+    B: T.Buffer[(128, 128), "float32"],
+    C: T.Buffer[(128, 128), "float32"],
+):
     for i, j, k in T.grid(128, 128, 128):
         with T.block("C"):
             vk, vj, vi = T.axis.remap("RSS", [k, j, i])


### PR DESCRIPTION
Currently there is no schedule primitive to reorder itervars inside blocks (`reorder` primitive only manipulate loop orders), this PR solves the issue.

This PR would be upstream to TVM later.