### PR TITLE
[Bugfix] Use `reverse_cache_read` for spmm example

### DIFF
--- a/docker/Dockerfile.ci_sparsetir_gpu
+++ b/docker/Dockerfile.ci_sparsetir_gpu
@@ -78,4 +78,4 @@ RUN bash docker/install/install_sparsetir_gpu.sh
 
 # Install dependencies required by lint
 RUN pip3 install flake8==5.0.4 pylint==2.15.6 cpplint==1.6.1 black==22.8.0
-RUN apt install -y default-jre
+RUN apt-get update --fix-missing && apt-get install -y default-jre

--- a/examples/spmm/bench_spmm.py
+++ b/examples/spmm/bench_spmm.py
@@ -173,7 +173,6 @@ def bench_hyb(
             sch.reorder(foo, fi, j, foi)
             if is_atomic:
                 sch.annotate(blk, "atomic", True)
-                # write_blk = sch.cache_write(blk, 0, "local")
                 write_blk = sch.reverse_cache_write(blk, 0, "local")
                 sch.reverse_compute_at(write_blk, fi, True)
                 # sch.unroll(sch.get_loops(write_blk)[-2])

--- a/examples/spmm/bench_spmm.py
+++ b/examples/spmm/bench_spmm.py
@@ -173,7 +173,8 @@ def bench_hyb(
             sch.reorder(foo, fi, j, foi)
             if is_atomic:
                 sch.annotate(blk, "atomic", True)
-                write_blk = sch.cache_write(blk, 0, "local")
+                # write_blk = sch.cache_write(blk, 0, "local")
+                write_blk = sch.reverse_cache_write(blk, 0, "local")
                 sch.reverse_compute_at(write_blk, fi, True)
                 # sch.unroll(sch.get_loops(write_blk)[-2])
             sch.bind(fi, "threadIdx.x")


### PR DESCRIPTION
# The Bug
This PR fixes issue #90 , which is because our `CompactBufferRegion` pass cannot infer the extent of `C_local` when there are non-affine expressions:
```
allocate(C_local_8: Pointer(local float32), float32, [(min(1710902, ((max(I_1_3_indices_data_1[((i_1_3_1: int32*8) + threadIdx.y_3: int32)], I_1_3_indices_data_1[0]) + 1) - min(I_1_3_indices_data_1[((i_1_3_1*8) + threadIdx.y_3)], I_1_3_indices_data_1[0])))*2)]), storage_scope = local;
```

which should be:
```
allocate(C_local_8: Pointer(local float32), float32, [2]), storage_scope = local;
```

# Solution

This PR uses `reverse_cache_read` (we are upstreaming its generalized form `reindex_cache_read/write`, see https://github.com/apache/tvm/pull/14161) whose generated buffer does not rely on `CompactBufferRegion` to determine its extent.