### PR TITLE
[Refactor] Rename `T.iter` to `T.sp_iter`

### DIFF
--- a/examples/blocksparse/bsr_spmm.py
+++ b/examples/blocksparse/bsr_spmm.py
@@ -49,7 +49,7 @@ def bsrmm(mb, nb, nnz, blk, feat_size):
         B = T.match_sparse_buffer(b, (J_detach, BJ, F), "float16")
         C = T.match_sparse_buffer(c, (I, BI, F), "float16")
 
-        with T.iter([I, BI, BJ, F, J], "SSRSR", "bsrmm") as [
+        with T.sp_iter([I, BI, BJ, F, J], "SSRSR", "bsrmm") as [
             i,
             bi,
             bj,
@@ -87,7 +87,7 @@ def dbsrmm(mb, nb, nnz0, nnz1, blk, feat_size):
         B = T.match_sparse_buffer(b, (J_detach, BJ, F), "float16")
         C = T.match_sparse_buffer(c, (I_detach, BI, F), "float16")
 
-        with T.iter([O, I, BI, BJ, F, J], "SSSRSR", "bsrmm") as [
+        with T.sp_iter([O, I, BI, BJ, F, J], "SSSRSR", "bsrmm") as [
             o,
             i,
             bi,

--- a/examples/rgms/rgcn/bench_rgcn_tensorcore.py
+++ b/examples/rgms/rgcn/bench_rgcn_tensorcore.py
@@ -590,7 +590,7 @@ def rgcn_hetero_forward(m, n, num_rels, feat_in, feat_out, dtype):
         Y = T.match_sparse_buffer(y, (I_detach, F_out), dtype)
         WX = T.match_sparse_buffer(wx, (R, I, J, F_out), dtype)
 
-        with T.iter([R, I, J, F_out, F_in], "SSSSR", "rgcn-hetero-forward_wx") as [
+        with T.sp_iter([R, I, J, F_out, F_in], "SSSSR", "rgcn-hetero-forward_wx") as [
             r,
             i,
             j,
@@ -601,7 +601,7 @@ def rgcn_hetero_forward(m, n, num_rels, feat_in, feat_out, dtype):
                 WX[r, i, j, fo] = T.cast(0, dtype)
             WX[r, i, j, fo] += T.cast(X[j, fi] * W[r, fi, fo], dtype)
 
-        with T.iter([R, I, J, F_out], "SSRS", "rgcn-hetero-forward") as [r, i, j, fo]:
+        with T.sp_iter([R, I, J, F_out], "SSRS", "rgcn-hetero-forward") as [r, i, j, fo]:
             with T.init():
                 Y[i, fo] = T.cast(0, dtype)
             Y[i, fo] = Y[i, fo] + T.cast(A[r, i, j], dtype) * WX[r, i, j, fo]

--- a/examples/rgms/rgcn/utils.py
+++ b/examples/rgms/rgcn/utils.py
@@ -81,7 +81,7 @@ def rgcn_hetero_forward(
     W = T.match_sparse_buffer(w, (R, F_out, F_in), "float32")
     X = T.match_sparse_buffer(x, (J_detach, F_in), "float32")
     Y = T.match_sparse_buffer(y, (I_detach, F_out), "float32")
-    with T.iter([F_out, R, I, J, F_in], "SSSRR", "rgcn-hetero-forward") as [fo, r, i, j, fi]:
+    with T.sp_iter([F_out, R, I, J, F_in], "SSSRR", "rgcn-hetero-forward") as [fo, r, i, j, fi]:
         with T.init():
             Y[i, fo] = 0.0
         Y[i, fo] = Y[i, fo] + A[r, i, j] * W[r, fo, fi] * X[j, fi]

--- a/examples/rgms/sparse_conv/rgms.py
+++ b/examples/rgms/sparse_conv/rgms.py
@@ -581,7 +581,7 @@ def rgcn_hetero_forward(m, n, num_rels, feat_in, feat_out):
         Y = T.match_sparse_buffer(y, (I_detach, F_out), "float16")
         WX = T.match_sparse_buffer(wx, (R, I, J, F_out), "float16")
 
-        with T.iter([R, I, J, F_out, F_in], "SSSSR", "rgcn-hetero-forward_wx") as [
+        with T.sp_iter([R, I, J, F_out, F_in], "SSSSR", "rgcn-hetero-forward_wx") as [
             r,
             i,
             j,
@@ -592,7 +592,7 @@ def rgcn_hetero_forward(m, n, num_rels, feat_in, feat_out):
                 WX[r, i, j, fo] = T.float16(0)
             WX[r, i, j, fo] += X[j, fi] * W[r, fi, fo]
 
-        with T.iter([R, I, J, F_out], "SSRS", "rgcn-hetero-forward") as [r, i, j, fo]:
+        with T.sp_iter([R, I, J, F_out], "SSRS", "rgcn-hetero-forward") as [r, i, j, fo]:
             with T.init():
                 Y[i, fo] = T.float16(0)
             Y[i, fo] = Y[i, fo] + A[r, i, j] * WX[r, i, j, fo]

--- a/examples/sddmm/bench_sddmm.py
+++ b/examples/sddmm/bench_sddmm.py
@@ -47,7 +47,7 @@ def sddmm(m: int, n: int, feat_size: int, nnz: int):
         B = T.match_sparse_buffer(b, (J_detach, K), "float32")
         C = T.match_sparse_buffer(c, (I, J), "float32")
 
-        with T.iter([I, J, K], "SSR", "sddmm") as [i, j, k]:
+        with T.sp_iter([I, J, K], "SSR", "sddmm") as [i, j, k]:
             with T.init():
                 C[i, j] = 0.0
             C[i, j] = C[i, j] + A[i, k] * B[j, k]

--- a/examples/spmm/bench_spmm.py
+++ b/examples/spmm/bench_spmm.py
@@ -58,7 +58,7 @@ def csrmm(
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (J_detach, K1, K2, K3), "float32")
     C = T.match_sparse_buffer(c, (I, K1, K2, K3), "float32")
-    with T.iter([I, J, K1, K2, K3], "SRSSS", "csrmm") as [i, j, k1, k2, k3]:
+    with T.sp_iter([I, J, K1, K2, K3], "SRSSS", "csrmm") as [i, j, k1, k2, k3]:
         with T.init():
             C[i, k1, k2, k3] = 0.0
         C[i, k1, k2, k3] = C[i, k1, k2, k3] + A[i, j] * B[j, k1, k2, k3]

--- a/examples/spmm/bench_spmm_naive.py
+++ b/examples/spmm/bench_spmm_naive.py
@@ -53,7 +53,7 @@ def csrmm(
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (J_detach, K1, K2, K3), "float32")
     C = T.match_sparse_buffer(c, (I, K1, K2, K3), "float32")
-    with T.iter([I, J, K1, K2, K3], "SRSSS", "csrmm") as [i, j, k1, k2, k3]:
+    with T.sp_iter([I, J, K1, K2, K3], "SRSSS", "csrmm") as [i, j, k1, k2, k3]:
         with T.init():
             C[i, k1, k2, k3] = T.float32(0)
         C[i, k1, k2, k3] = C[i, k1, k2, k3] + A[i, j] * B[j, k1, k2, k3]

--- a/examples/spmm/bench_tc_spmm.py
+++ b/examples/spmm/bench_tc_spmm.py
@@ -559,7 +559,7 @@ def tcspmm(
     A = T.match_sparse_buffer(a, [IO, JO, II, JI], "float16")
     B = T.match_sparse_buffer(b, [J, F], "float16")
     C = T.match_sparse_buffer(c, [IO, II, F], "float16")
-    with T.iter([IO, JO, II, JI, F], "SRSRS", "tcspmm") as [io, jo, ii, ji, f]:
+    with T.sp_iter([IO, JO, II, JI, F], "SRSRS", "tcspmm") as [io, jo, ii, ji, f]:
         with T.init():
             C[io, ii, f] = T.float16(0)
         C[io, ii, f] = C[io, ii, f] + A[io, jo, ii, ji] * B[ji, f]

--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -448,8 +448,44 @@ class BlockAttr(SpecialStmt):
 
 
 @register
-class IterAttr(SpecialStmt):
-    """Special function iter_attr({attr_key: attr_value})
+class SparseIterationAttr(SpecialStmt):
+    """Special function sp_iter_attr({attr_key: attr_value})
+
+    Example
+    -------
+    .. code-block:: python
+
+        T.sp_iter_attr({"preprocess": True})
+    """
+
+    def __init__(self):
+        def sp_iter_attr(attrs: Mapping[str, Object], span: Span = None):
+            assert self.context, "call 'exit_scope' before 'enter_scope'"
+            block_scope = self.context.current_block_scope()
+            if block_scope is None:
+                self.context.report_error(
+                    "Expected to declare block annotations inside a block.",
+                    span,
+                )
+            if block_scope.annotations is not None:
+                self.context.report_error(
+                    "Duplicate block annotations declaration, "
+                    + "previous one is "
+                    + str(block_scope.annotations),
+                    span,
+                )
+            attrs = {
+                key: String(val) if isinstance(val, str) else val for key, val in attrs.items()
+            }
+            block_scope.annotations = attrs
+
+        super().__init__(sp_iter_attr, def_symbol=False)
+
+
+@register
+class LegacySparseIterationAttr(SpecialStmt):
+    """Legacy Sparse Iteration Attribution API to ensure compatibility.
+    iter_attr({attr_key: attr_value})
 
     Example
     -------

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1539,7 +1539,7 @@ Doc TVMScriptPrinter::VisitStmt_(const BlockRealizeNode* op) {
 
 Doc TVMScriptPrinter::PrintSparseIterationName(const SparseIterationNode* op) {
   Doc doc;
-  doc << "with " << tir_prefix_ << ".iter([";
+  doc << "with " << tir_prefix_ << ".sp_iter([";
 
   int n_iter = static_cast<int>(op->sp_iter_vars.size());
 

--- a/tests/python/sparsetir/sparse_tir_composable_format_scripts.py
+++ b/tests/python/sparsetir/sparse_tir_composable_format_scripts.py
@@ -175,32 +175,32 @@ def bsr_rewrite_with_preprocess(
     A_32 = T.match_sparse_buffer(a_32, [IO_32, JO_32, II_32, JI_32], dtype="float32")
     # body
     # with T.block("root")
-    with T.iter([IO_4, JO_4, II_4, JI_4], "SSSS", "rewrite_A_4") as [io_4, jo_4, ii_4, ji_4]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([IO_4, JO_4, II_4, JI_4], "SSSS", "rewrite_A_4") as [io_4, jo_4, ii_4, ji_4]:
+        T.sp_iter_attr({"preprocess": True})
         A_4[io_4, jo_4, ii_4, ji_4] = A[io_4 * 4 + ii_4, jo_4 * 4 + ji_4]
-    with T.iter([IO_16, JO_16, II_16, JI_16], "SSSS", "rewrite_A_16") as [
+    with T.sp_iter([IO_16, JO_16, II_16, JI_16], "SSSS", "rewrite_A_16") as [
         io_16,
         jo_16,
         ii_16,
         ji_16,
     ]:
-        T.iter_attr({"preprocess": True})
+        T.sp_iter_attr({"preprocess": True})
         A_16[io_16, jo_16, ii_16, ji_16] = A[io_16 * 16 + ii_16, jo_16 * 16 + ji_16]
-    with T.iter([IO_32, JO_32, II_32, JI_32], "SSSS", "rewrite_A_32") as [
+    with T.sp_iter([IO_32, JO_32, II_32, JI_32], "SSSS", "rewrite_A_32") as [
         io_32,
         jo_32,
         ii_32,
         ji_32,
     ]:
-        T.iter_attr({"preprocess": True})
+        T.sp_iter_attr({"preprocess": True})
         A_32[io_32, jo_32, ii_32, ji_32] = A[io_32 * 32 + ii_32, jo_32 * 32 + ji_32]
-    with T.iter([IO_4, II_4, JO_4, JI_4, K], "SSRRS", "csrmm_4") as [io_4, ii_4, jo_4, ji_4, k]:
+    with T.sp_iter([IO_4, II_4, JO_4, JI_4, K], "SSRRS", "csrmm_4") as [io_4, ii_4, jo_4, ji_4, k]:
         with T.init():
             C[io_4 * 4 + ii_4, k] = T.float32(0)
         C[io_4 * 4 + ii_4, k] = (
             C[io_4 * 4 + ii_4, k] + A_4[io_4, jo_4, ii_4, ji_4] * B[jo_4 * 4 + ji_4, k]
         )
-    with T.iter([IO_16, II_16, JO_16, JI_16, K], "SSRRS", "csrmm_16") as [
+    with T.sp_iter([IO_16, II_16, JO_16, JI_16, K], "SSRRS", "csrmm_16") as [
         io_16,
         ii_16,
         jo_16,
@@ -212,7 +212,7 @@ def bsr_rewrite_with_preprocess(
         C[io_16 * 16 + ii_16, k] = (
             C[io_16 * 16 + ii_16, k] + A_16[io_16, jo_16, ii_16, ji_16] * B[jo_16 * 16 + ji_16, k]
         )
-    with T.iter([IO_32, II_32, JO_32, JI_32, K], "SSRRS", "csrmm_32") as [
+    with T.sp_iter([IO_32, II_32, JO_32, JI_32, K], "SSRRS", "csrmm_32") as [
         io_32,
         ii_32,
         jo_32,
@@ -328,52 +328,52 @@ def ell_rewrite_with_preprocess(
     A_512 = T.match_sparse_buffer(a_512, [O_512, I_512, J_512], dtype="float32")
     # body
     # with T.block("root")
-    with T.iter([O_4, I_4, J_4], "SSS", "rewrite_A_4") as [o_4, i_4, j_4]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_4, I_4, J_4], "SSS", "rewrite_A_4") as [o_4, i_4, j_4]:
+        T.sp_iter_attr({"preprocess": True})
         A_4[o_4, i_4, j_4] = A[i_4, j_4]
-    with T.iter([O_8, I_8, J_8], "SSS", "rewrite_A_8") as [o_8, i_8, j_8]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_8, I_8, J_8], "SSS", "rewrite_A_8") as [o_8, i_8, j_8]:
+        T.sp_iter_attr({"preprocess": True})
         A_8[o_8, i_8, j_8] = A[i_8, j_8]
-    with T.iter([O_16, I_16, J_16], "SSS", "rewrite_A_16") as [o_16, i_16, j_16]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_16, I_16, J_16], "SSS", "rewrite_A_16") as [o_16, i_16, j_16]:
+        T.sp_iter_attr({"preprocess": True})
         A_16[o_16, i_16, j_16] = A[i_16, j_16]
-    with T.iter([O_32, I_32, J_32], "SSS", "rewrite_A_32") as [o_32, i_32, j_32]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_32, I_32, J_32], "SSS", "rewrite_A_32") as [o_32, i_32, j_32]:
+        T.sp_iter_attr({"preprocess": True})
         A_32[o_32, i_32, j_32] = A[i_32, j_32]
-    with T.iter([O_64, I_64, J_64], "SSS", "rewrite_A_64") as [o_64, i_64, j_64]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_64, I_64, J_64], "SSS", "rewrite_A_64") as [o_64, i_64, j_64]:
+        T.sp_iter_attr({"preprocess": True})
         A_64[o_64, i_64, j_64] = A[i_64, j_64]
-    with T.iter([O_128, I_128, J_128], "SSS", "rewrite_A_128") as [o_128, i_128, j_128]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_128, I_128, J_128], "SSS", "rewrite_A_128") as [o_128, i_128, j_128]:
+        T.sp_iter_attr({"preprocess": True})
         A_128[o_128, i_128, j_128] = A[i_128, j_128]
-    with T.iter([O_512, I_512, J_512], "SSS", "rewrite_A_512") as [o_512, i_512, j_512]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([O_512, I_512, J_512], "SSS", "rewrite_A_512") as [o_512, i_512, j_512]:
+        T.sp_iter_attr({"preprocess": True})
         A_512[o_512, i_512, j_512] = A[i_512, j_512]
-    with T.iter([O_4, I_4, J_4, K], "SSRS", "csrmm_4") as [o_4, i_4, j_4, k]:
+    with T.sp_iter([O_4, I_4, J_4, K], "SSRS", "csrmm_4") as [o_4, i_4, j_4, k]:
         with T.init():
             C[i_4, k] = T.float32(0)
         C[i_4, k] = C[i_4, k] + A_4[o_4, i_4, j_4] * B[j_4, k]
-    with T.iter([O_8, I_8, J_8, K], "SSRS", "csrmm_8") as [o_8, i_8, j_8, k]:
+    with T.sp_iter([O_8, I_8, J_8, K], "SSRS", "csrmm_8") as [o_8, i_8, j_8, k]:
         with T.init():
             C[i_8, k] = T.float32(0)
         C[i_8, k] = C[i_8, k] + A_8[o_8, i_8, j_8] * B[j_8, k]
-    with T.iter([O_16, I_16, J_16, K], "SSRS", "csrmm_16") as [o_16, i_16, j_16, k]:
+    with T.sp_iter([O_16, I_16, J_16, K], "SSRS", "csrmm_16") as [o_16, i_16, j_16, k]:
         with T.init():
             C[i_16, k] = T.float32(0)
         C[i_16, k] = C[i_16, k] + A_16[o_16, i_16, j_16] * B[j_16, k]
-    with T.iter([O_32, I_32, J_32, K], "SSRS", "csrmm_32") as [o_32, i_32, j_32, k]:
+    with T.sp_iter([O_32, I_32, J_32, K], "SSRS", "csrmm_32") as [o_32, i_32, j_32, k]:
         with T.init():
             C[i_32, k] = T.float32(0)
         C[i_32, k] = C[i_32, k] + A_32[o_32, i_32, j_32] * B[j_32, k]
-    with T.iter([O_64, I_64, J_64, K], "SSRS", "csrmm_64") as [o_64, i_64, j_64, k]:
+    with T.sp_iter([O_64, I_64, J_64, K], "SSRS", "csrmm_64") as [o_64, i_64, j_64, k]:
         with T.init():
             C[i_64, k] = T.float32(0)
         C[i_64, k] = C[i_64, k] + A_64[o_64, i_64, j_64] * B[j_64, k]
-    with T.iter([O_128, I_128, J_128, K], "SSRS", "csrmm_128") as [o_128, i_128, j_128, k]:
+    with T.sp_iter([O_128, I_128, J_128, K], "SSRS", "csrmm_128") as [o_128, i_128, j_128, k]:
         with T.init():
             C[i_128, k] = T.float32(0)
         C[i_128, k] = C[i_128, k] + A_128[o_128, i_128, j_128] * B[j_128, k]
-    with T.iter([O_512, I_512, J_512, K], "SSRS", "csrmm_512") as [o_512, i_512, j_512, k]:
+    with T.sp_iter([O_512, I_512, J_512, K], "SSRS", "csrmm_512") as [o_512, i_512, j_512, k]:
         with T.init():
             C[i_512, k] = T.float32(0)
         C[i_512, k] = C[i_512, k] + A_512[o_512, i_512, j_512] * B[j_512, k]
@@ -412,10 +412,10 @@ def padding_rewrite_with_preprocess(
     A_32 = T.match_sparse_buffer(a_32, [I_32, JO_32, JI_32], dtype="float32")
     # body
     # with T.block("root")
-    with T.iter([I_32, JO_32, JI_32], "SSS", "rewrite_A_32") as [i_32, jo_32, ji_32]:
-        T.iter_attr({"preprocess": True})
+    with T.sp_iter([I_32, JO_32, JI_32], "SSS", "rewrite_A_32") as [i_32, jo_32, ji_32]:
+        T.sp_iter_attr({"preprocess": True})
         A_32[i_32, jo_32, ji_32] = A[i_32, ji_32]
-    with T.iter([I_32, JO_32, JI_32, K], "SRRS", "csrmm_32") as [i_32, jo_32, ji_32, k]:
+    with T.sp_iter([I_32, JO_32, JI_32, K], "SRRS", "csrmm_32") as [i_32, jo_32, ji_32, k]:
         with T.init():
             C[i_32, k] = T.float32(0)
         C[i_32, k] = C[i_32, k] + A_32[i_32, jo_32, ji_32] * B[ji_32, k]

--- a/tests/python/sparsetir/sparse_tir_scripts.py
+++ b/tests/python/sparsetir/sparse_tir_scripts.py
@@ -38,7 +38,7 @@ def csrmm(
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (J_detach, K), "float32")
     C = T.match_sparse_buffer(c, (I, K), "float32")
-    with T.iter([I, J, K], "SRS", "csrmm") as [i, j, k]:
+    with T.sp_iter([I, J, K], "SRS", "csrmm") as [i, j, k]:
         with T.init():
             C[i, k] = 0.0
         C[i, k] = C[i, k] + A[i, j] * B[j, k]
@@ -64,7 +64,7 @@ def csrmm_dense_iter(
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (J_detach, K), "float32")
     C = T.match_sparse_buffer(c, (I, K), "float32")
-    with T.iter([I, J_detach, K], "SRS", "csrmm") as [i, j, k]:
+    with T.sp_iter([I, J_detach, K], "SRS", "csrmm") as [i, j, k]:
         with T.init():
             C[i, k] = 0.0
         C[i, k] = C[i, k] + A[i, j] * B[j, k]
@@ -83,7 +83,7 @@ def segment_reduce(
     J = T.dense_variable(I, (100, nnz), indptr, "int32")
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (I,), "float32")
-    with T.iter([I, J], "SR", "segment_reduce") as [i, j]:
+    with T.sp_iter([I, J], "SR", "segment_reduce") as [i, j]:
         with T.init():
             B[i] = 0.0
         B[i] = B[i] + A[i, j]
@@ -104,7 +104,7 @@ def csr_reduce(
     J = T.sparse_variable(I, (m, nnz), (indptr, indices), "int32")
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (I,), "float32")
-    with T.iter([I, J], "SR", "csr_reduce") as [i, j]:
+    with T.sp_iter([I, J], "SR", "csr_reduce") as [i, j]:
         with T.init():
             B[i] = 0.0
         B[i] = B[i] + A[i, j]
@@ -134,7 +134,7 @@ def bsrmm(
     B = T.match_sparse_buffer(b, (J_detach, BJ, F), "float32")
     C = T.match_sparse_buffer(c, (I, BI, F), "float32")
 
-    with T.iter([I, BI, BJ, F, J], "SSRSR", "bsrmm") as [
+    with T.sp_iter([I, BI, BJ, F, J], "SSRSR", "bsrmm") as [
         i,
         bi,
         bj,
@@ -169,7 +169,7 @@ def ellmm(
     B = T.match_sparse_buffer(b, (J_detach, BJ, F), "float32")
     C = T.match_sparse_buffer(c, (I, BI, F), "float32")
 
-    with T.iter([I, J, BI, BJ, F], "SRSRS", "ellmm") as [
+    with T.sp_iter([I, J, BI, BJ, F], "SRSRS", "ellmm") as [
         i,
         j,
         bi,
@@ -197,7 +197,7 @@ def csr_element_wise(
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (I, J), "float32")
 
-    with T.iter([I, J], "SS", "csr_element_wise") as [i, j]:
+    with T.sp_iter([I, J], "SS", "csr_element_wise") as [i, j]:
         B[i, j] = A[i, j] * 2.5
 
 
@@ -222,7 +222,7 @@ def hyper_gnn(
     I_T = T.sparse_variable(J_detach, (n, nnz), (indptr_T, indices_T), "int32")
     X = T.match_sparse_buffer(x, (I, F), "float32")
     Y = T.match_sparse_buffer(y, (I, F), "float32")
-    with T.iter([I, F, J, T.attach(I_T, J)], "SSRR", "hyper_gnn") as [i, f, j, i_t]:
+    with T.sp_iter([I, F, J, T.attach(I_T, J)], "SSRR", "hyper_gnn") as [i, f, j, i_t]:
         with T.init():
             Y[i, f] = T.float32(0)
         Y[i, f] = Y[i, f] + X[i_t, f]
@@ -258,7 +258,7 @@ def bmm(
     X = T.match_sparse_buffer(x, (B, I, IJ), "float32")
     Y = T.match_sparse_buffer(y, (B, J, JK), "float32")
     Z = T.match_sparse_buffer(z, (B, I, IK), "float32")
-    with T.iter([B, I, J, K], "SSRS", "bmm") as [b, i, j, k]:
+    with T.sp_iter([B, I, J, K], "SSRS", "bmm") as [b, i, j, k]:
         with T.init():
             Z[b, i, k] = 0.0
         Z[b, i, k] = Z[b, i, k] + X[b, i, j] * Y[b, j, k]
@@ -285,7 +285,7 @@ def sddmm(
     B = T.match_sparse_buffer(b, (J_detach, K), "float32")
     C = T.match_sparse_buffer(c, (I, J), "float32")
 
-    with T.iter([I, J, K], "SSR", "sddmm") as [i, j, k]:
+    with T.sp_iter([I, J, K], "SSR", "sddmm") as [i, j, k]:
         with T.init():
             C[i, j] = 0.0
         C[i, j] = C[i, j] + A[i, k] * B[j, k]
@@ -312,7 +312,7 @@ def fused_sddmm(
     B = T.match_sparse_buffer(b, (J_detach, K), "float32")
     C = T.match_sparse_buffer(c, (I, J), "float32")
 
-    with T.iter([T.fuse(I, J), K], "SSR", "sddmm") as [i, j, k]:
+    with T.sp_iter([T.fuse(I, J), K], "SSR", "sddmm") as [i, j, k]:
         with T.init():
             C[i, j] = 0.0
         C[i, j] = C[i, j] + A[i, k] * B[j, k]
@@ -339,7 +339,7 @@ def square_sum(
     A = T.match_sparse_buffer(a, (I, J, K), "float32")
     B = T.match_sparse_buffer(b, (I,), "float32")
 
-    with T.iter([I, J, K], "SRR", "square_sum") as [i, j, k]:
+    with T.sp_iter([I, J, K], "SRR", "square_sum") as [i, j, k]:
         with T.init():
             B[i] = 0.0
         B[i] = B[i] + A[i, j, k]
@@ -372,7 +372,7 @@ def square_sum_two_K(
     A = T.match_sparse_buffer(a, (I, J, K0), "float32")
     B = T.match_sparse_buffer(b, (I,), "float32")
 
-    with T.iter([I, J, K1], "SRR", "square_sum") as [i, j, k]:
+    with T.sp_iter([I, J, K1], "SRR", "square_sum") as [i, j, k]:
         with T.init():
             B[i] = 0.0
         B[i] = B[i] + A[i, j, k]
@@ -397,7 +397,7 @@ def fused_reduction_4d_2d(
     L = T.dense_variable(K, (32768, nnz_l), indptr_l, "int32")
     X = T.match_sparse_buffer(x, (I, J, K, L), "float32")
     Y = T.match_sparse_buffer(y, (I, J), "float32")
-    with T.iter([T.fuse(I, J), K, L], "SSRR", "reduction_4d_2d") as [i, j, k, l]:
+    with T.sp_iter([T.fuse(I, J), K, L], "SSRR", "reduction_4d_2d") as [i, j, k, l]:
         with T.init():
             Y[i, j] = 0.0
         Y[i, j] = Y[i, j] + X[i, j, k, l]
@@ -422,7 +422,7 @@ def fused_reduction_4d_3d(
     L = T.dense_variable(K, (32768, nnz_l), indptr_l, "int32")
     X = T.match_sparse_buffer(x, (I, J, K, L), "float32")
     Y = T.match_sparse_buffer(y, (I, J, K), "float32")
-    with T.iter([T.fuse(I, J, K), L], "SSSR", "reduction_4d_3d") as [i, j, k, l]:
+    with T.sp_iter([T.fuse(I, J, K), L], "SSSR", "reduction_4d_3d") as [i, j, k, l]:
         with T.init():
             Y[i, j, k] = 0.0
         Y[i, j, k] = Y[i, j, k] + X[i, j, k, l]
@@ -453,7 +453,7 @@ def rgcn_homo_forward(
     W = T.match_sparse_buffer(w, (R, F_out, F_in), "float32")
     X = T.match_sparse_buffer(x, (J_detach, F_in), "float32")
     Y = T.match_sparse_buffer(y, (I, F_out), "float32")
-    with T.iter([I, F_out, J, F_in], "SSRR", "rgcn-homo-forward") as [
+    with T.sp_iter([I, F_out, J, F_in], "SSRR", "rgcn-homo-forward") as [
         i,
         fo,
         j,
@@ -493,7 +493,7 @@ def rgcn_hetero_forward(
     W = T.match_sparse_buffer(w, (R, F_out, F_in), "float32")
     X = T.match_sparse_buffer(x, (J_detach, F_in), "float32")
     Y = T.match_sparse_buffer(y, (I_detach, F_out), "float32")
-    with T.iter([F_out, R, I, J, F_in], "SSSRR", "rgcn-hetero-forward") as [fo, r, i, j, fi]:
+    with T.sp_iter([F_out, R, I, J, F_in], "SSSRR", "rgcn-hetero-forward") as [fo, r, i, j, fi]:
         with T.init():
             Y[i, fo] = 0.0
         Y[i, fo] = Y[i, fo] + A[r, i, j] * W[r, fo, fi] * X[j, fi]
@@ -515,16 +515,16 @@ def sparse_softmax(
     B = T.match_sparse_buffer(b, (I, J), "float32")
     TMP = T.alloc_sparse_buffer((I,), "float32", "global")
     TMP1 = T.alloc_sparse_buffer((I,), "float32", "global")
-    with T.iter([I], "S", "sparse_softmax") as [i]:
-        with T.iter([J], "R", "computer_max") as [j]:
+    with T.sp_iter([I], "S", "sparse_softmax") as [i]:
+        with T.sp_iter([J], "R", "computer_max") as [j]:
             with T.init():
                 TMP[i] = T.min_value("float32")
             TMP[i] = T.max(TMP[i], A[i, j])
-        with T.iter([J], "R", "exp_and_sum") as [j]:
+        with T.sp_iter([J], "R", "exp_and_sum") as [j]:
             with T.init():
                 TMP1[i] = T.float32(0)
             TMP1[i] = TMP1[i] + T.exp(A[i, j] - TMP[i], dtype="float32")
-        with T.iter([J], "S", "div") as [j]:
+        with T.sp_iter([J], "S", "div") as [j]:
             B[i, j] = T.exp(A[i, j], dtype="float32") / TMP1[i]
 
 
@@ -553,5 +553,5 @@ def csr2bsr(
     BJ = T.dense_fixed(blk_size)
     A = T.match_sparse_buffer(a, (I, J), "float32")
     B = T.match_sparse_buffer(b, (I_bsr, J_bsr, BI, BJ), "float32")
-    with T.iter([I, J], "SS", "csr2bsr") as [i, j]:
+    with T.sp_iter([I, J], "SS", "csr2bsr") as [i, j]:
         B[i // blk_size, j // blk_size, i % blk_size, j % blk_size] = A[i, j]

--- a/tests/python/sparsetir/test_merging_binary_search.py
+++ b/tests/python/sparsetir/test_merging_binary_search.py
@@ -26,7 +26,7 @@ def func(indptr: T.handle, indices: T.handle, m: T.int32, n: T.int32, nnz: T.int
     I = T.dense_fixed(m)
     J = T.sparse_variable(I, (n, nnz), (indptr, indices))
     A = T.alloc_sparse_buffer([I, J], "float32")
-    with T.iter([T.fuse(I, J)], "SS", "test") as [vi, vj]:
+    with T.sp_iter([T.fuse(I, J)], "SS", "test") as [vi, vj]:
         A[vi, vj] = (vi + vj) * (vi - vj)
 
 

--- a/tests/python/sparsetir/test_reverse_cache_read_write.py
+++ b/tests/python/sparsetir/test_reverse_cache_read_write.py
@@ -47,7 +47,7 @@ def tcspmm(
     A = T.match_sparse_buffer(a, [IO, JO, II, JI], "float16")
     B = T.match_sparse_buffer(b, [J, F], "float16")
     C = T.match_sparse_buffer(c, [IO, II, F], "float16")
-    with T.iter([IO, JO, II, JI, F], "SRSRS", "tcspmm") as [io, jo, ii, ji, f]:
+    with T.sp_iter([IO, JO, II, JI, F], "SRSRS", "tcspmm") as [io, jo, ii, ji, f]:
         with T.init():
             C[io, ii, f] = T.float16(0)
         C[io, ii, f] = C[io, ii, f] + A[io, jo, ii, ji] * B[ji, f]

--- a/tests/python/sparsetir/test_stage_i_schedule.py
+++ b/tests/python/sparsetir/test_stage_i_schedule.py
@@ -49,7 +49,7 @@ def reordered_bsrmm(
     B = T.match_sparse_buffer(b, (J_detach, BJ, F), "float32")
     C = T.match_sparse_buffer(c, (I, BI, F), "float32")
 
-    with T.iter([BI, BJ, I, J, F], "SRSRS", "bsrmm") as [
+    with T.sp_iter([BI, BJ, I, J, F], "SRSRS", "bsrmm") as [
         vbi,
         vbj,
         vi,


### PR DESCRIPTION
Our paper uses `sp_iter` to construct sparse iterations. This PR renames all appearance of `T.iter` to `T.sp_iter` to align with paper.