### PR TITLE
Add an `exact_match` argument to `BinarySearch` function in Sparse Iteration Lowering pass

### DIFF
--- a/src/tir/transforms/lower_sparse_iter.cc
+++ b/src/tir/transforms/lower_sparse_iter.cc
@@ -891,7 +891,7 @@ class IterTransformer : public StmtExprMutator {
     args.push_back(lb);
     args.push_back(ub);
     args.push_back(val);
-    args.push_back(Integer(int(search_type)));
+    args.push_back(Integer(static_cast<int>(search_type)));
     args.push_back(Bool(minus_one));
     if (bsearch_map_.count(args)) {
       return bsearch_map_[args];


### PR DESCRIPTION
Currently we only have `lower_bound` and `upper_bound` like binary search functions, which is not enough to express exact binary search semantics.

This PR adds an `exact_match` argument in `BinarySearch` function, if it's set to True, we generate another `found_match` buffer that stores whether search is an exact match or not.

The generated `found_match` buffer could then be used in other scenarios such as #95 .